### PR TITLE
Remove Twig sandbox from template renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Remove Twig Sandbox from template renderer — templates are admin-only, so the restriction provided no security benefit and blocked legitimate filters like `date_modify` and `slice`
+
 ## [0.1.0] – 2026-03-03
 
 ### Security

--- a/includes/class-kurso-renderer.php
+++ b/includes/class-kurso-renderer.php
@@ -4,8 +4,6 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\Error\Error as TwigError;
-use Twig\Extension\SandboxExtension;
-use Twig\Sandbox\SecurityPolicy;
 
 class Kurso_Renderer {
 
@@ -54,17 +52,8 @@ class Kurso_Renderer {
         }
 
         try {
-            $loader  = new ArrayLoader( [ 'template' => $template ] );
-            $policy  = new SecurityPolicy(
-                [ 'if', 'for', 'set' ],
-                [ 'escape', 'date', 'length', 'default', 'join', 'lower', 'upper', 'trim', 'number_format', 'raw', 'nl2br', 'format' ],
-                [],
-                [],
-                [ 'date', 'max', 'min' ]
-            );
-            $sandbox = new SandboxExtension( $policy, true );
-            $twig    = new Environment( $loader, [ 'autoescape' => 'html' ] );
-            $twig->addExtension( $sandbox );
+            $loader = new ArrayLoader( [ 'template' => $template ] );
+            $twig   = new Environment( $loader, [ 'autoescape' => 'html' ] );
             return $twig->render( 'template', $data );
         } catch ( TwigError $e ) {
             return new WP_Error( 'kurso_twig', $e->getMessage() );


### PR DESCRIPTION
Templates are admin-only (manage_options), so the SecurityPolicy provided no real security benefit while blocking legitimate filters like date_modify and slice.

The variables preprocessor in class-kurso-graphql.php retains its sandbox since it handles user-influenced JSON input.