### PR TITLE
Add shortcode column with copy button and page builder docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Shortcode** column with copy button in the query list — the shortcode is now always visible, no longer only when a cache exists
+- Documentation for usage with page builders (Elementor, WPBakery, BeBuilder) in README, readme.txt and specification
+
 ## [0.1.1] – 2026-03-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ query {
 
 Drag the **"KURSO Display"** block from the *Embeds* category into the editor. Select query and template in the sidebar.
 
+### Page Builders
+
+The shortcode works in all common page builders — no extra configuration needed. Copy the shortcode for each query via the **Copy** button under *Settings → KURSO → Queries*.
+
+- **Elementor (including Free):** Add a **Shortcode** widget and paste `[kurso query="my-query"]`.
+- **WPBakery:** Add a **Text Block** element and paste the shortcode.
+- **BeBuilder (BeTheme):** Add a **Plain text** item (Section → Wrap → *+ Item* → Plain text) and paste the shortcode. Do **not** use the *Code* item — it displays shortcodes as text instead of executing them.
+
 ## Twig Syntax Quick Reference
 
 | Expression | Meaning |

--- a/admin/class-kurso-admin.php
+++ b/admin/class-kurso-admin.php
@@ -186,6 +186,7 @@ class Kurso_Admin {
                 <tr>
                     <th><?php esc_html_e( 'Name', 'kurso-wordpress' ); ?></th>
                     <th><?php esc_html_e( 'Slug', 'kurso-wordpress' ); ?></th>
+                    <th><?php esc_html_e( 'Shortcode', 'kurso-wordpress' ); ?></th>
                     <th><?php esc_html_e( 'Interval', 'kurso-wordpress' ); ?></th>
                     <th><?php esc_html_e( 'Last fetch', 'kurso-wordpress' ); ?></th>
                     <th><?php esc_html_e( 'Actions', 'kurso-wordpress' ); ?></th>
@@ -201,6 +202,14 @@ class Kurso_Admin {
                 <tr>
                     <td><strong><?php echo esc_html( $q['name'] ?? $slug ); ?></strong></td>
                     <td><code><?php echo esc_html( $slug ); ?></code></td>
+                    <td class="kurso-shortcode-cell">
+                        <?php $shortcode = '[kurso query="' . $slug . '"]'; ?>
+                        <code><?php echo esc_html( $shortcode ); ?></code>
+                        <button type="button"
+                                class="button button-small kurso-copy-shortcode"
+                                data-shortcode="<?php echo esc_attr( $shortcode ); ?>"
+                                data-copied-label="<?php esc_attr_e( 'Copied ✓', 'kurso-wordpress' ); ?>"><?php esc_html_e( 'Copy', 'kurso-wordpress' ); ?></button>
+                    </td>
                     <td><?php echo esc_html( $q['interval'] ?? 60 ); ?> min</td>
                     <td>
                         <?php if ( $last_fetch ) : ?>
@@ -225,13 +234,6 @@ class Kurso_Admin {
                         <a href="<?php echo esc_url( admin_url( 'admin-post.php?action=kurso_delete_query&slug=' . urlencode( $slug ) . '&_wpnonce=' . wp_create_nonce( 'kurso_delete_query_' . $slug ) ) ); ?>"
                            class="button button-small button-link-delete"
                            onclick="return confirm('<?php echo esc_js( sprintf( __( 'Really delete query "%s"?', 'kurso-wordpress' ), $slug ) ); ?>')"><?php esc_html_e( 'Delete', 'kurso-wordpress' ); ?></a>
-
-                        <?php if ( $has_cache ) : ?>
-                        <details class="kurso-shortcode-hint">
-                            <summary><?php esc_html_e( 'Shortcode', 'kurso-wordpress' ); ?></summary>
-                            <code>[kurso query="<?php echo esc_html( $slug ); ?>"]</code>
-                        </details>
-                        <?php endif; ?>
                     </td>
                 </tr>
             <?php endforeach; ?>

--- a/assets/css/kurso-admin.css
+++ b/assets/css/kurso-admin.css
@@ -47,6 +47,5 @@
 .kurso-badge { display: inline-block; padding: 2px 8px; border-radius: 3px; font-size: 12px; font-weight: 600; }
 .kurso-badge--ok { background: #d4edda; color: #155724; }
 .kurso-badge--warn { background: #fff3cd; color: #856404; }
-.kurso-shortcode-hint { margin-top: 6px; }
-.kurso-shortcode-hint summary { cursor: pointer; color: #2271b1; font-size: 12px; }
-.kurso-shortcode-hint code { display: block; background: #f6f7f7; padding: 4px 8px; margin-top: 4px; font-size: 12px; }
+.kurso-shortcode-cell { white-space: nowrap; }
+.kurso-shortcode-cell code { background: #f6f7f7; padding: 4px 8px; font-size: 12px; margin-right: 6px; }

--- a/assets/js/kurso-admin.js
+++ b/assets/js/kurso-admin.js
@@ -126,6 +126,39 @@ jQuery(function ($) {
         });
     });
 
+    // Copy shortcode to clipboard (queries list)
+    $(document).on('click', '.kurso-copy-shortcode', function () {
+        var $btn      = $(this);
+        // .attr() instead of .data(): jQuery would try to JSON-parse values starting with "["
+        var shortcode = $btn.attr('data-shortcode');
+
+        function showFeedback() {
+            var original = $btn.text();
+            $btn.text($btn.data('copied-label')).prop('disabled', true);
+            setTimeout(function () {
+                $btn.text(original).prop('disabled', false);
+            }, 1500);
+        }
+
+        if (navigator.clipboard && window.isSecureContext) {
+            navigator.clipboard.writeText(shortcode).then(showFeedback);
+            return;
+        }
+
+        // Fallback for non-secure contexts (plain HTTP admin)
+        var textarea = document.createElement('textarea');
+        textarea.value = shortcode;
+        textarea.style.position = 'fixed';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+            document.execCommand('copy');
+            showFeedback();
+        } catch (e) {}
+        document.body.removeChild(textarea);
+    });
+
     // -------------------------------------------------------------------------
     // CodeMirror editors — only initialized if CodeMirror is available.
     // Use window.kursoCM (saved before other plugins can overwrite window.CodeMirror).

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === KURSO for WordPress ===
 Contributors: kurso
-Tags: kurse, graphql, twig, shortcode, gutenberg
+Tags: kurse, graphql, twig, shortcode, gutenberg, elementor
 Requires at least: 6.0
 Tested up to: 6.0
 Requires PHP: 8.0
@@ -19,6 +19,7 @@ Das Plugin bietet:
 * Verbindung zur KURSO-API
 * Konfigurierbare Datenabfragen
 * Ausgabe per Gutenberg-Block oder Shortcode
+* Kompatibel mit Page Buildern (Elementor, WPBakery, BeBuilder) per Shortcode
 * Automatische Aktualisierung der Daten im Hintergrund
 
 Hinweis:
@@ -45,6 +46,14 @@ Mit dem KURSO-Block im Editor oder per Shortcode, z. B.:
 Optional mit CSS-Klasse:
 
 `[kurso query="meine-query" class="meine-klasse"]`
+
+= Funktioniert das Plugin mit Page Buildern (Elementor, WPBakery, BeBuilder)? =
+
+Ja, über den Shortcode. Kopieren Sie den Shortcode der gewünschten Query unter `Einstellungen -> KURSO -> Queries` und fügen Sie ihn ein:
+
+* **Elementor (auch Free):** Shortcode-Widget verwenden.
+* **WPBakery:** Text-Block-Element verwenden.
+* **BeBuilder (BeTheme):** Element "Plain text" verwenden (nicht das "Code"-Element — dieses zeigt Shortcodes nur an, statt sie auszuführen).
 
 = Wo richten Sie die Verbindung zu KURSO ein? =
 

--- a/specs/specification.md
+++ b/specs/specification.md
@@ -352,6 +352,23 @@ Passend zu einer Query wie `{ Course(id: "123") { name startDate endDate locatio
 | `template` | Slug eines gespeicherten Templates | am Query hinterlegtes Template |
 | `class` | Zusätzliche CSS-Klasse für den Container | — |
 
+Der Shortcode jeder Query kann in der Query-Übersicht (`Einstellungen → KURSO → Queries`) per **Kopieren-Button** in die Zwischenablage übernommen werden.
+
+### Page-Builder-Integration
+
+Seiten, die nicht mit Gutenberg gebaut sind, binden die Ausgabe über den Shortcode ein. Es ist kein builder-spezifischer Code nötig:
+
+| Builder | Weg |
+|---|---|
+| Elementor (auch Free) | Shortcode-Widget |
+| WPBakery | Text-Block-Element |
+| BeBuilder (BeTheme) | Element „Plain text" (Section → Wrap → „+ Item"). **Nicht** das „Code"-Element — es zeigt Shortcodes nur an, statt sie auszuführen. |
+
+Hinweise:
+
+- In BeBuilder stehen Gutenberg-Blöcke nicht zur Verfügung (BeBuilder ersetzt den Gutenberg-Editor); BeBuilder bietet keine dokumentierte API für eigene Elemente.
+- Native Elemente für Elementor (Widget) und WPBakery (`vc_map`) sind bewusst zurückgestellt, bis Nachfrage besteht (siehe Offene Punkte).
+
 ---
 
 ## Datenfluss
@@ -476,4 +493,6 @@ filter: {
 - [ ] Suchfilter im Frontend (z.B. nach Ort oder Kurstyp filtern)
 - [ ] Mehrsprachigkeit (WPML-Kompatibilität)
 - [ ] Webhook-Support: KURSO triggert WordPress direkt bei Datenänderung (statt Polling)
-- [ ] Shortcode-Generator im Admin für nicht-technische Nutzer
+- [x] Shortcode-Generator im Admin für nicht-technische Nutzer *(erledigt: Shortcode-Spalte mit Kopieren-Button in der Query-Übersicht)*
+- [ ] Natives Elementor-Widget (Query-Dropdown statt Shortcode) — bei Bedarf
+- [ ] Natives WPBakery-Element via `vc_map` — bei Bedarf


### PR DESCRIPTION
## Summary

Many WordPress sites don't use Gutenberg but page builders like Elementor, WPBakery or BeBuilder. The existing `[kurso query="..."]` shortcode already works in all of them — this PR closes the discoverability gap instead of adding builder-specific code:

- **Shortcode column in the query list**: the shortcode is now always visible for every query (previously hidden unless a cache existed) with a **copy-to-clipboard button** (`navigator.clipboard` with `execCommand` fallback for plain-HTTP admins)
- **Page builder documentation** in README, readme.txt (FAQ) and the specification: Elementor → Shortcode widget, WPBakery → Text Block, BeBuilder → "Plain text" item (explicitly *not* the "Code" item, which displays shortcodes instead of executing them)
- Spec open item "Shortcode-Generator im Admin" checked off; native Elementor/WPBakery elements added as new optional backlog items

## Testing

Verified end-to-end on wp-dev.henke-informatik.com with a fresh plugin build:

- Shortcode column renders for queries **with and without** cache (incl. "Never" badge case, which was broken before)
- Copy button tested in headless Chrome: click → "Copied ✓" → clipboard contains exactly `[kurso query="demo-kurse"]` → button resets after 1.5 s
- Frontend regression: `/kurso-test/` page renders the course table with `kurso-frontend.css` enqueued
- Query create/delete regression OK; `php -l` and `node --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
